### PR TITLE
Container update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:3.4
 
 MAINTAINER Julien Kernec'h <docker@dial-once.com>
 
@@ -11,10 +11,14 @@ RUN apk update \
   # Install base packages and ruby gem dependencies
   && apk add --no-cache bash tar bc build-base ca-certificates wget libffi-dev \
   # Install ruby and ruby-bundler
-  && apk add --no-cache ruby-dev ruby-bundler \
+  && apk add --no-cache ruby-dev ruby-bundler ruby-rdoc ruby-irb \
   # Do not install Gem documentation when installing gems
   && echo "install: --no-rdoc --no-ri" >> /etc/gemrc \
+  # Update Rubygems to latest (have a bug with sensu in default Alpine:3.4)
+  && gem install rubygems-update && update_rubygems && gem update --system \
   # Install sensu gem
   && gem install sensu \
   # Install dockerize
-  && wget -O - https://github.com/jwilder/dockerize/releases/download/v${DOCKERIZE_VERSION}/dockerize-linux-amd64-v${DOCKERIZE_VERSION}.tar.gz | tar -xzf - -C /usr/local/bin
+  && wget -O - https://github.com/jwilder/dockerize/releases/download/v${DOCKERIZE_VERSION}/dockerize-linux-amd64-v${DOCKERIZE_VERSION}.tar.gz | tar -xzf - -C /usr/local/bin \
+  # Cleanup no-more-used packages
+  && apk del ruby-irb ruby-rdoc wget bash tar ca-certificates


### PR DESCRIPTION
# Fixes
- Use Alpine:3.4 instead of latest
- Fix build errors on rubygems version (bundled with Alpine 3.4)
- Packages cleanup after sensu install

Tested against #dial-once/docker-sensu-client

Reviewers: @mrister @jkernech @ky23 
