### PR TITLE
Silent docker login command so it don't print in CI systems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ run:
 	docker run -it $(NAMESPACE)/$(IMAGE)
 
 push:
-	docker login -e $(DOCKER_EMAIL) -u $(DOCKER_USER) -p $(DOCKER_PASS)
+	@docker login -e $(DOCKER_EMAIL) -u $(DOCKER_USER) -p $(DOCKER_PASS)
 	docker push $(NAMESPACE)/$(IMAGE):$(VERSION)
 
 .PHONY: build


### PR DESCRIPTION
We should always silent commands that outputs some credentials, in any project (public or private)

Fixes #3 

For acknowledgement: @dial-once/developers 

Once acked, master should be re-written to avoid future build launch of any previous commit to reveal credentials on this project and:

  dial-once/docker-sensu-client
  dial-once/docker-sensu-server
  dial-once/docker-sensu-api
